### PR TITLE
fix: add-to-playlist folder flyout trapped by backdrop-filter

### DIFF
--- a/user.css
+++ b/user.css
@@ -222,7 +222,6 @@
 .VwcQJ4Zsf0JKD3Ls,
 .wJiY1vDfuci2a4db,
 .Wzl40f9FIUD91O2o,
-.xamNkt5LX9o8aL1q,
 .x-settings-section,
 .yZCluNwEsPD2zYyY,
 .zddkQq3wlxEOg6aa,
@@ -2029,6 +2028,18 @@ button.e-10451-legacy-button.e-10451-legacy-button-tertiary.e-10451-overflow-wra
   border-radius: 20px;
   box-shadow: var(--glowify-shadow);
   outline: var(--glowify-outline, none) !important;
+}
+
+/* The "Add to playlist" popup must not carry backdrop-filter itself. A
+   backdrop-filter other than `none` makes an element a containing block for
+   absolutely/fixed positioned descendants, and this form also carries
+   Spotify's own `overflow: auto` — so the folder flyout got clipped and turned
+   into scrollbars instead of expanding outwards. Blurring the Tippy wrapper
+   gives the identical frosted look without clipping, since the wrapper has no
+   overflow restriction. */
+[data-tippy-root]:has(.xamNkt5LX9o8aL1q) {
+  backdrop-filter: blur(var(--glowify-backdrop-blur, 2rem));
+  border-radius: 20px;
 }
 
 .UmC7B1blaToOXizU {


### PR DESCRIPTION
## Problem

In the **Add to playlist** popup, folder rows don't expand when hovered, and the popup
shows a stray horizontal scrollbar plus an oversized vertical one.

Steps to reproduce:
1. Right-click any track → **Add to playlist**
2. Hover a playlist *folder* row
3. The folder's flyout doesn't appear; instead the popup grows a horizontal scrollbar

**Before:**

<img width="292" height="427" alt="add_to_playlist_bug" src="https://github.com/user-attachments/assets/bb1f3f1c-1b41-40f5-bfd6-72caed3aeb3e" />


## Cause

`user.css` includes the popup's form in the big `backdrop-filter` selector list
(line 225, `.xamNkt5LX9o8aL1q`):

```css
.xamNkt5LX9o8aL1q,
...
dialog {
  background: transparent;
  backdrop-filter: blur(var(--glowify-backdrop-blur, 2rem));
  outline: var(--glowify-outline, none) !important;
}
```

A `backdrop-filter` other than `none` makes an element a **containing block for
absolutely- and fixed-positioned descendants**
([MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter#description)).
That same form also carries Spotify's own `overflow: auto`. Spotify renders the folder
flyout as a separate Tippy portal positioned to escape the popup — but the blur made the
form its containing block, so the flyout was laid out *inside* the form and clipped,
turning into scroll instead of an expanding submenu. Measured with the popup open:
`scrollWidth` 572 vs `clientWidth` 292, i.e. exactly the flyout's width in overflow.

## Fix

Remove the form from the `backdrop-filter` list and blur the Tippy wrapper instead. The
wrapper has no overflow restriction, so the popup looks identical while no longer
trapping the flyout. Spotify's `overflow: auto` on the form is left untouched — once the
form isn't a containing block, the flyout no longer contributes to its layout, so no
scrollbar appears.

After the patch, same measurement:

| | before | after |
|---|---|---|
| form `backdrop-filter` | `blur(32px)` | `none` |
| wrapper `backdrop-filter` | `none` | `blur(32px)` |
| form `scrollWidth` / `clientWidth` | 572 / 292 | 292 / 292 |
| horizontal scrollbar | yes | no |
| flyout escapes popup | no | yes |

The frosted look on the popup is unchanged.

**After:**

<img width="683" height="590" alt="Screenshot_20260904_180409" src="https://github.com/user-attachments/assets/4846ff18-390a-47cb-9a37-6c8b31498814" />

## Testing

Verified on **Spotify 1.2.89.539** (Flatpak, Linux) / Chrome 146 / Spicetify 2.43.2,
with Glowify installed via Marketplace. Confirmed by applying the patched CSS to the
running client and measuring computed styles and element geometry via the Chrome
DevTools Protocol, then re-checking the flyout by hand.

Note: `.xamNkt5LX9o8aL1q` is a Spotify build hash and may change on future client
updates — same fragility as the existing rules around it, so this doesn't add any new
maintenance burden, but worth knowing if the symptom ever returns.The popup's form (.xamNkt5LX9o8aL1q) was included in the backdrop-filter selector list. A backdrop-filter other than `none` makes an element a containing block for absolutely/fixed positioned descendants, and this form also carries Spotify's own overflow:auto -- so the folder flyout was laid out inside the form and clipped, becoming a horizontal scrollbar instead of an expanding submenu.

Blur the Tippy wrapper instead. It has no overflow restriction, so the popup looks identical while no longer trapping the flyout. Spotify's overflow:auto is left untouched; with the form no longer a containing block the flyout does not contribute to its layout, so no scrollbar appears.

Measured with the popup open, before: scrollWidth 572 vs clientWidth 292.
After: 292/292, flyout escapes correctly, frosted look unchanged.

Tested on Spotify 1.2.89.539 (Flatpak) / Chrome 146 / Spicetify 2.43.2.